### PR TITLE
Updating Fontenehuset link on about us page

### DIFF
--- a/src/app/[locale]/om-oss/page.tsx
+++ b/src/app/[locale]/om-oss/page.tsx
@@ -31,7 +31,7 @@ export default async function OmOss() {
       image: '/fontenelogo 1.png',
       title: t('about.partners.fontenehuset.title'),
       text: t('about.partners.fontenehuset.text'),
-      link: 'https://www.fontenehuset.no',
+      link: 'https://www.fontenehusetbergen.no/',
     },
     {
       image: '/glode-logo 1.png',


### PR DESCRIPTION
Changing link from https://www.fontenehuset.no/ to https://www.fontenehusetbergen.no/ which is the specific page for the Bergen department