### PR TITLE
Sanity lib tags hotfix

### DIFF
--- a/src/lib/sanity/fetch.ts
+++ b/src/lib/sanity/fetch.ts
@@ -16,8 +16,9 @@ import { sanityFetch } from './client';
  * const available = allLocales.map(doc => doc.language); // ['nb','sv',...]
  */
 export async function getTiltakById({ index }: GetTiltakById): Promise<Tiltak[]> {
+  const baseType = 'tiltak' satisfies Tiltak['_type'];
   const query = sanityGenerateTiltakQuery(index);
-  const tags = ['tiltak', `tiltak:${index}`];
+  const tags = ['sanity', baseType, `${baseType}:${index}`];
 
   return await sanityFetch<Tiltak[]>({
     query,
@@ -36,8 +37,9 @@ export async function getTiltakByIdLocalized({
   index,
   locale,
 }: GetTiltakByLocale): Promise<Tiltak | null> {
+  const baseType = 'tiltak' satisfies Tiltak['_type'];
   const query = sanityGenerateTiltakLocalizedQuery(index, locale);
-  const tags = ['sanity', 'tiltak', `tiltak:${index}:${locale}`];
+  const tags = ['sanity', baseType, `${baseType}:${index}:${locale}`];
 
   return await sanityFetch<Tiltak>({
     query,
@@ -53,8 +55,9 @@ export async function getTiltakByIdLocalized({
  * if (!contacts.length) notFound();
  */
 export async function getContacts(): Promise<Contacts[]> {
+  const baseType = 'contacts' satisfies Contacts['_type'];
   const query = sanityGenerateContactsQuery();
-  const tags = ['sanity', 'contacts'];
+  const tags = ['sanity', baseType];
 
   return await sanityFetch<Contacts[]>({
     query,


### PR DESCRIPTION
Updated the tags used in sanity fetching lib to match the type names of their respective schemas which fixes type missmatching when using the webhook feature in Sanity.io to revalidate data serverside